### PR TITLE
upgrade node version to current

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,20 +4,20 @@
     "main": "index.js",
     "version": "1.1.0",
     "engines": {
-        "gitbook": ">=2.5.0"
-    },
-    "dependencies": {
-        "q": "^1.1.2",
-        "node-sass": "3.4.1",
-        "lodash": "^3.10.0"
+    "gitbook": ">=2.5.0"
+  },
+  "dependencies": {
+    "q": "^1.1.2",
+    "node-sass": "^4.1.1",
+    "lodash": "^3.10.0"
     },
     "homepage": "https://github.com/GitbookIO/plugin-styles-sass",
     "repository": {
         "type": "git",
         "url": "https://github.com/GitbookIO/plugin-styles-sass.git"
     },
-    "license": "Apache-2.0",
-    "bugs": {
-        "url": "https://github.com/GitbookIO/plugin-styles-sass/issues"
-    }
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/GitbookIO/plugin-styles-sass/issues"
+  }
 }


### PR DESCRIPTION
The node-sass version `3.4.1` doesn't exist anymore and therefore the whole plugin doesn't work anymore.

I upgraded the version to the newest one which appears to work.

See also issue: https://github.com/GitbookIO/plugin-styles-sass/issues/6